### PR TITLE
For excluding ACF field-groups defined in DB, only pick ACF fields that ...

### DIFF
--- a/advanced-custom-fields-wpcli.php
+++ b/advanced-custom-fields-wpcli.php
@@ -26,7 +26,7 @@ if ( ! defined( 'WP_CLI' ) ) {
     global $blog_id;
     if ( function_exists( "register_field_group" ) ) :
       global $wpdb;
-    $db_field_groups = $wpdb->get_results( "SELECT post_title FROM {$wpdb->posts} WHERE post_type='acf'" );
+    $db_field_groups = $wpdb->get_results( "SELECT post_title FROM {$wpdb->posts} WHERE post_type='acf' AND post_status='publish';" );
 
     $db_field_group_titles = array();
     foreach ( $db_field_groups as $db_group ) :


### PR DESCRIPTION
...are in publish state, let the field groups in trash stay there
