### PR TITLE
Allow export path to be specified via command

### DIFF
--- a/ACF5_Command.php
+++ b/ACF5_Command.php
@@ -93,7 +93,12 @@ class ACF5_Command extends WP_CLI_Command {
 
     if ( $field_groups ) {
 
-      $export_path = $this->select_export_path();
+      if ( isset( $assoc_args['export-path'] ) && isset($this->paths[ $assoc_args['export-path'] ] ) ) {
+        $export_path = $this->paths[ $assoc_args['export-path'] ];
+      } else {
+        $export_path = $this->select_export_path();
+      }
+
 
       $acf_fld_grp = new acf_field();
 


### PR DESCRIPTION
Now I've upgraded to ACF 5 and have set it up an export path for my plugin, it would be useful to skip the prompt stage for my build scripts.
