### PR TITLE
Fix bug related to user field groups

### DIFF
--- a/advanced-custom-fields-wpcli.php
+++ b/advanced-custom-fields-wpcli.php
@@ -54,16 +54,23 @@ if ( ! defined( 'WP_CLI' ) ) {
     }
 
     $added_groups = array();
+    $files = array();
+    // collect list of all field group files in various locations
     foreach ( $patterns as $pattern ) {
       // register the field groups specific for this subsite
       foreach ( glob( $pattern ) as $file ) {
-        $group = acf_wpcli_get_file_data( $file );
-
-        // Don't register group when the group is already in the DB
-        if ( ! in_array( $group['title'] , $db_field_group_titles ) )
-          register_field_group( $group );
-        $added_groups[] = $group['title'];
+        $files[] = $file;
       }
+    }
+
+    // do not double process field group files
+    foreach ( array_unique( $files ) as $file ) {
+      $group = acf_wpcli_get_file_data( $file );
+
+      // Don't register group when the group is already in the DB
+      if ( ! in_array( $group['title'] , $db_field_group_titles ) )
+        register_field_group( $group );
+      $added_groups[] = $group['title'];
     }
 
     endif;


### PR DESCRIPTION
The previous logic was calling `register_field_group` twice for every `data.php` file you had _if_ you project did not have a child theme.  Basically, the problem was that the `$paths` variable had duplicate paths for `active_theme` and `active_child_theme`.  For field groups on custom post types, this actually didn't cause any problems.  However, if you create a field group for your users, it would end up resulting in the user form double rendering all of the custom fields.

The change here makes it so that all `$files` are collected, duplicates removed, and then processed individually.
