### PR TITLE
Check if pattern path exists

### DIFF
--- a/advanced-custom-fields-wpcli.php
+++ b/advanced-custom-fields-wpcli.php
@@ -50,6 +50,9 @@ if ( ! defined( 'WP_CLI' ) ) {
     $patterns = array();
 
     foreach ( $paths as $key => $value ) {
+      if( ! is_dir($value) ){
+        continue;
+      }
       $patterns[ $key ] = trailingslashit( $value ) . '*/data.php';
     }
 


### PR DESCRIPTION
Because else it returns a notice on the `glob` at `foreach ( glob( $pattern ) as $file ) {` because the directory doesn't exists.

Running ACF5 with ACF 4 field-groups on WP 4.0.1.
