### PR TITLE
Fixed import argument

### DIFF
--- a/ACF5_Command.php
+++ b/ACF5_Command.php
@@ -371,6 +371,8 @@ class ACF5_Command extends WP_CLI_Command {
 
           break;
         }
+      } else {
+        $choice = $args[0];
       }
 
       $patterns = array();


### PR DESCRIPTION
The command `wp acf import all` throws an undefined variable notice. This pull request fixes this.