### PR TITLE
Preserve field order when importing

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -4,10 +4,8 @@ namespace ACFWPCLI;
 
 class Field {
 
-  public static function import( $field, $field_group ) {
-    $order = array();
-
-     // add parent
+  public static function import( $field, $field_group, &$order ) {
+    // add parent
     if ( empty( $field['parent'] ) ) {
       $field['parent'] = $field_group['ID'];
     } elseif ( isset( $ref[ $field['parent'] ] ) ) {

--- a/src/Fieldgroup.php
+++ b/src/Fieldgroup.php
@@ -40,7 +40,7 @@ class Fieldgroup {
 
       // add fields
       foreach ( $fields as $field ) {
-        Field::import( $field, $field_group );
+        Field::import( $field, $field_group, $order );
       }
 
       WP_CLI::success( 'imported the data.json for field_group "' . $field_group['title'] .'" into the dabatase!' );


### PR DESCRIPTION
The order of fields in a field group was not being preserved when importing the field group. This PR fixes that issue.
