### PR TITLE
Add trailingslashit() to $export_path

### DIFF
--- a/lib/acfwpcli/cli.php
+++ b/lib/acfwpcli/cli.php
@@ -87,7 +87,7 @@ class CLI extends WP_CLI_Command {
 
     foreach ( $field_groups as $post ) {
       $field_group = \ACFWPCLI\FieldGroup::to_array( $post );
-      $file = $export_path . sanitize_title( $post->post_title ) . '.json';
+      $file = trailingslashit( $export_path ) . sanitize_title( $post->post_title ) . '.json';
 
       \ACFWPCLI\FieldGroup::to_json_file( $field_group, $file );
       WP_CLI::success( "Exported field group: {$post->post_title}" );


### PR DESCRIPTION
When leaving out the trailing slash the export becomes `directorynamefilename.json` instead of `directory/filename.json` and all files get exported to the same level.

Filter:
```
function wt_acfwpcli_fieldgroup_paths(){
    return [ get_template_directory_uri() . '/field-groups'];
}
add_filter('acfwpcli_fieldgroup_paths', 'wt_acfwpcli_fieldgroup_paths');
```