### PR TITLE
Add "all" option to import command

### DIFF
--- a/src/Commands/ACF5_Command.php
+++ b/src/Commands/ACF5_Command.php
@@ -220,7 +220,10 @@ class ACF5_Command extends WP_CLI_Command {
       WP_CLI::warning( 'You are runnning a multisite. Use the --url=<url> parameter to specify which site you want to target.' );
     }
 
-    if ( isset( $group ) ) {
+    if (isset($all) && $all ) {
+      $choice = 'all';
+    }
+    else if ( isset( $group ) ) {
       $choice = $this->get_path_by_groupname( $group );
     } else {
       $choice = $this->select_import_fieldgroup();


### PR DESCRIPTION
Hello,
I just added here "all" option check in order to be able to call import command in a deploy process (which I do).
With this update, running "wp acf import --all" will import all files found in registered path, without any user prompt.

Thanks for your work,

Nicolas