### PR TITLE
fix output directory when not / suffixed

### DIFF
--- a/features/checkbox.feature
+++ b/features/checkbox.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Checkbox Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='checkbox-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' checkbox-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/clone.feature
+++ b/features/clone.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Clone Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='clone-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' clone-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/color_picker.feature
+++ b/features/color_picker.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Color Picker Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='color_picker-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' color_picker-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/date_picker.feature
+++ b/features/date_picker.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Date Picker Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='date_picker-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' date_picker-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/date_time_picker.feature
+++ b/features/date_time_picker.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Date Time Picker Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='date_time_picker-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' date_time_picker-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/dboverfile.feature
+++ b/features/dboverfile.feature
@@ -3,6 +3,6 @@ Feature: DB is prefered over files
     Scenario: Export a field group and see if changes to the db over prefered over export files
         Given a WP install
         And a "number" feature
-        When I run the command "acf export --field_group='number-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' number-group"
         And I remove the fields from "number-group.json"
         Then the "number-group" should not have been added to the local groups

--- a/features/email.feature
+++ b/features/email.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Email Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='email-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' email-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/embed.feature
+++ b/features/embed.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Embed Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='embed-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' embed-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/file.feature
+++ b/features/file.feature
@@ -7,7 +7,7 @@ Feature: Import and Export File Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='file-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' file-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/flexible.feature
+++ b/features/flexible.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Flexible Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='flexible-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' flexible-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/gallery.feature
+++ b/features/gallery.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Gallery Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='gallery-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' gallery-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/google_maps.feature
+++ b/features/google_maps.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Google Maps Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='google_maps-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' google_maps-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/image.feature
+++ b/features/image.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Image Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='image-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' image-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/message.feature
+++ b/features/message.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Gallery Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='message-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' message-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/multiple.feature
+++ b/features/multiple.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Group With Multiple Fields
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='multiple-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' multiple-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/number.feature
+++ b/features/number.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Number Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='number-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' number-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/page_link.feature
+++ b/features/page_link.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Page Link Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='page_link-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' page_link-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/password.feature
+++ b/features/password.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Password Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='password-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' password-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/post.feature
+++ b/features/post.feature
@@ -7,7 +7,7 @@ Feature: Import and Export post Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='post-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' post-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/radio.feature
+++ b/features/radio.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Radio Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='radio-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' radio-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/relation.feature
+++ b/features/relation.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Relation Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='relation-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' relation-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/repeater.feature
+++ b/features/repeater.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Repeater Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='repeater-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' repeater-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/select.feature
+++ b/features/select.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Select Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='select-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' select-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/tab.feature
+++ b/features/tab.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Tab Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='tab-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' tab-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/taxonomy.feature
+++ b/features/taxonomy.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Taxonomy Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='taxonomy-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' taxonomy-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/text.feature
+++ b/features/text.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Text Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='text-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' text-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/textarea.feature
+++ b/features/textarea.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Text Area Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='textarea-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' textarea-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/time_picker.feature
+++ b/features/time_picker.feature
@@ -7,7 +7,7 @@ Feature: Import and Export Time Picker Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='time_picker-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' time_picker-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/truefalse.feature
+++ b/features/truefalse.feature
@@ -7,7 +7,7 @@ Feature: Import and Export TRUE/FALSE Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='truefalse-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' truefalse-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/url.feature
+++ b/features/url.feature
@@ -7,7 +7,7 @@ Feature: Import and Export URL Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='url-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' url-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/user.feature
+++ b/features/user.feature
@@ -7,7 +7,7 @@ Feature: Import and Export User Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='user-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' user-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/features/wysiwyg.feature
+++ b/features/wysiwyg.feature
@@ -7,7 +7,7 @@ Feature: Import and Export WYSIWYG Groups
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"
-        When I run the command "acf export --field_group='wysiwyg-group' --export_path='features/bootstrap/test_exports/'"
+        When I run the command "acf export --export_path='features/bootstrap/test_exports/' wysiwyg-group"
         Then the exit code should be 0
         And the result should not be empty
         And the result string should start with "Success:"

--- a/lib/acfwpcli/cli.php
+++ b/lib/acfwpcli/cli.php
@@ -40,7 +40,7 @@ class CLI extends WP_CLI_Command {
   *
   * ## OPTIONS
   *
-  * [--field_group=<field_group>]
+  * [<field_group>...]
   * : The field group to export, can be used with "My Field Group" or "my-field-group".
   *
   * [--export_path=<path>]
@@ -50,10 +50,11 @@ class CLI extends WP_CLI_Command {
   * : Export all the fieldgroups.
   *
   * @subcommand export
-  * @synopsis [--field_group=<field_group>] [--export_path=<export_path>] [--all]
+  * @synopsis [--export_path=<export_path>] [--all] [<field_group>]
   */
   function export( $args, $assoc_args ) {
     extract( $assoc_args );
+    $field_group = $args[0];
 
     $field_groups = [];
 

--- a/lib/acfwpcli/cli.php
+++ b/lib/acfwpcli/cli.php
@@ -89,7 +89,7 @@ class CLI extends WP_CLI_Command {
 
     foreach ( $field_groups as $post ) {
       $field_group = \ACFWPCLI\FieldGroup::to_array( $post );
-      $file = $export_path . sanitize_title( $post->post_title ) . '.json';
+      $file = $export_path . '/' . sanitize_title( $post->post_title ) . '.json';
 
       \ACFWPCLI\FieldGroup::to_json_file( [$field_group], $file );
       WP_CLI::success( "Exported field group: {$post->post_title}" );


### PR DESCRIPTION
$ `acf  export --export_path=/tmp/dir --field_group=foo`
* creates a `/tmp/dir` directory
* outputs the ACF inside a `/tmp/dirfoo.json` file

=> Fix this behavior.
Note: double-/ does not hurt