### PR TITLE
Fix/post status any

### DIFF
--- a/features/bootstrap/test_imports/inactive-group.json
+++ b/features/bootstrap/test_imports/inactive-group.json
@@ -1,0 +1,44 @@
+[
+    {
+        "key": "group_580096d78bf25",
+        "title": "text-group",
+        "fields": [
+            {
+                "key": "field_580096e85e147",
+                "label": "text field",
+                "name": "text_field",
+                "type": "text",
+                "instructions": "This is inactive text field",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "default value",
+                "placeholder": "placeholder",
+                "prepend": "prepend",
+                "append": "append",
+                "maxlength": 40
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "post_type",
+                    "operator": "==",
+                    "value": "post"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": 0,
+        "description": "Group_Description"
+    }
+]

--- a/features/inactive.feature
+++ b/features/inactive.feature
@@ -1,0 +1,14 @@
+Feature: Import and Export Inactive Groups
+
+    Scenario: Importing and exporting a field group with an inactive status
+        Given a WP install
+        Then the exit code should be 0
+        When I run the command "acf import --json_file='features/bootstrap/test_imports/inactive-group.json'"
+        Then the exit code should be 0
+        And the result should not be empty
+        And the result string should start with "Success:"
+        When I run the command "acf export --field_group='inactive-group' --export_path='features/bootstrap/test_exports/'"
+        Then the exit code should be 0
+        And the result should not be empty
+        And the result string should start with "Success:"
+        And the imported and exported "inactive-group.json" files should match

--- a/lib/acfwpcli/field_group.php
+++ b/lib/acfwpcli/field_group.php
@@ -30,6 +30,7 @@ class FieldGroup {
     return get_posts([
         'numberposts' => -1,
         'post_type'   => 'acf-field-group',
+        'post_status' => 'any',
         'sort_column' => 'menu_order',
         'order'       => 'ASC',
     ]);


### PR DESCRIPTION
This PR fixes an issue with `wp acf export --all`, which doesn't export field groups with `active: 0`.