### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Fields can now easily be imported, exported and shared over SVN, GIT or comparab
 
 Install WP-CLI as described on [http://wp-cli.org/](http://wp-cli.org/ "WP-CLI")
 
+Using WP-CLI:
+
+```sh
+wp plugin install "https://github.com/hoppinger/advanced-custom-fields-wpcli/archive/master.zip" --activate
+```
+
 Using composer: (doesn't work for now until we have released the plugin on wordpress.org/plugins)
 ```
 composer require wpackagist-plugin/advanced-custom-fields-wpcli


### PR DESCRIPTION
Once you have WP-CLI installed and you intend to use it, the most natural way of installing a plugin is `wp plugin install`.