### PR TITLE
Use 'array()' instead of '[]' to instantiate new array objects

### DIFF
--- a/features/bootstrap/CommandFeature.php
+++ b/features/bootstrap/CommandFeature.php
@@ -2,7 +2,7 @@
 
 class CommandFeature
 {
-    protected $config = [];
+    protected $config = array();
 
     public function __construct()
     {

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -11,7 +11,7 @@ use Behat\Behat\Context\Context;
  */
 class FeatureContext extends CommandFeature implements Context
 {
-    private $result = [];
+    private $result = array();
 
     private $importsPath = '';
     private $exportsPath = '';
@@ -119,7 +119,7 @@ class FeatureContext extends CommandFeature implements Context
         $jsonString = file_get_contents($this->exportsPath.$file);
         $arr = json_decode($jsonString, true);
 
-        $arr[0]['fields'] = [];
+        $arr[0]['fields'] = array();
 
         $fp = fopen($this->exportsPath.$file, 'w');
         fwrite($fp, json_encode($arr));

--- a/features/bootstrap/config/config.php
+++ b/features/bootstrap/config/config.php
@@ -1,6 +1,6 @@
 <?php
 
-$config = [];
+$config = array();
 $config['wordpress_path'] = str_replace('features/bootstrap/config', '', dirname(__FILE__)).'wordpress/';
 $config['wp-cli_path'] = $config['wordpress_path'].'wp-cli.phar';
 

--- a/lib/acfwpcli.php
+++ b/lib/acfwpcli.php
@@ -2,7 +2,7 @@
 
 class ACFWPCLI {
 
-  private $added_groups = [];
+  private $added_groups = array();
 
   public function __construct() {
     $this->register_cli_command();
@@ -21,14 +21,14 @@ class ACFWPCLI {
 
     $db_field_groups = ACFWPCLI\FieldGroup::all();
 
-    $db_field_group_titles = [];
+    $db_field_group_titles = array();
     foreach ( $db_field_groups as $db_group ) {
       $db_field_group_titles[] = $db_group->post_title;
     }
 
-    $paths    = [];
+    $paths    = array();
     $paths    = apply_filters( 'acfwpcli_fieldgroup_paths', $paths );
-    $patterns = [];
+    $patterns = array();
 
     foreach ( $paths as $key => $value ) {
       if ( ! is_dir( $value ) ) {
@@ -37,7 +37,7 @@ class ACFWPCLI {
       $patterns[ $key ] = trailingslashit( $value ) . '*.json';
     }
 
-    $added_groups = [];
+    $added_groups = array();
     foreach ( $patterns as $pattern ) {
       // register the field groups specific for this subsite
       foreach ( glob( $pattern ) as $file ) {

--- a/lib/acfwpcli/cli.php
+++ b/lib/acfwpcli/cli.php
@@ -17,12 +17,12 @@ use ACFWPCLI\JSON;
  */
 
 class CLI extends WP_CLI_Command {
-  private $paths = [];
+  private $paths = array();
 
   function __construct() {
     $wpcli_config = WP_CLI::get_config();
 
-    $this->paths = [];
+    $this->paths = array();
     $this->paths = apply_filters( 'acfwpcli_fieldgroup_paths', $this->paths );
 
     if ( is_multisite( ) && ! isset( $wpcli_config['url'] ) ) {
@@ -55,7 +55,7 @@ class CLI extends WP_CLI_Command {
   function export( $args, $assoc_args ) {
     extract( $assoc_args );
 
-    $field_groups = [];
+    $field_groups = array();
 
     if ( isset( $field_group ) ) {
       $name = sanitize_title( $field_group );
@@ -145,7 +145,7 @@ class CLI extends WP_CLI_Command {
       $choice = $this->menu_choice_import_field_group();
     }
 
-    $patterns = [];
+    $patterns = array();
     if ( $choice == 'all' ) {
       foreach ( $this->paths as $key => $value ) {
         $patterns[ $key ] = trailingslashit( $value ) . '*.json'; }
@@ -185,7 +185,7 @@ class CLI extends WP_CLI_Command {
       return array_shift( $this->paths );
     }
 
-    $choices  = [];
+    $choices  = array();
 
     foreach ( $this->paths as $key => $value ) {
       $choices[ $value ] = $key . ': ' . $value;
@@ -195,10 +195,10 @@ class CLI extends WP_CLI_Command {
   }
 
   private function menu_choice_import_field_group() {
-    $choices = [];
+    $choices = array();
     $choices['all'] = 'all';
 
-    $patterns = [];
+    $patterns = array();
 
     foreach ( $this->paths as $path ) {
       $patterns[] = trailingslashit( $path ) . '*.json';

--- a/lib/acfwpcli/field.php
+++ b/lib/acfwpcli/field.php
@@ -5,7 +5,7 @@ namespace ACFWPCLI;
 class Field {
 
   public static function import( $field, $field_group ) {
-    $order = [];
+    $order = array();
 
      // add parent
     if ( empty( $field['parent'] ) ) {
@@ -30,12 +30,12 @@ class Field {
   }
 
   public static function all() {
-    return get_posts([
+    return get_posts(array(
         'numberposts' => -1,
         'post_type'   => array( 'acf', 'acf-field' ),
         'sort_column' => 'menu_order',
         'order'       => 'ASC',
-    ]);
+    ));
   }
 
   public static function destroy( $id ) {

--- a/lib/acfwpcli/field_group.php
+++ b/lib/acfwpcli/field_group.php
@@ -33,12 +33,12 @@ class FieldGroup {
   }
 
   public static function all() {
-    return get_posts([
+    return get_posts(array(
         'numberposts' => -1,
         'post_type'   => 'acf-field-group',
         'sort_column' => 'menu_order',
         'order'       => 'ASC',
-    ]);
+    ));
   }
 
   public static function find_by_name( $name ) {


### PR DESCRIPTION
Prevents the plugin from breaking your site when running legacy PHP versions.